### PR TITLE
feat: add accumulator sysvar feature to feature set

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -595,7 +595,6 @@ pub mod disable_builtin_loader_ownership_chains {
 }
 
 pub mod enable_accumulator_sysvar {
-    // note - this is just some random pubkey I generated on my local machine
     solana_sdk::declare_id!("BawYFA2oeA4CacxgQgLn6ZwRWDq1ZPXruUuEbko8oPT5");
 }
 
@@ -742,7 +741,7 @@ lazy_static! {
         (update_hashes_per_tick::id(), "Update desired hashes per tick on epoch boundary"),
         (enable_big_mod_exp_syscall::id(), "add big_mod_exp syscall #28503"),
         (disable_builtin_loader_ownership_chains::id(), "disable builtin loader ownership chains #29956"),
-        (enable_accumulator_sysvar::id(), "enable accumulator sysvar #<GH_ISSUE_NUMBER>"),
+        (enable_accumulator_sysvar::id(), "enable accumulator sysvar"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
**Note: the keypair listed in this PR/feature is temporary and just for testing/PoC purposes.**

Add feature for new sysvar

## Build:
```
# clone and checkout branch
git clone https://github.com/pyth-network/pythnet && cd pythnet && git checkout test-sysvar-feature-flag

## build under custom tag (taken from jito-labs docs)
export TAG=v1.15.0-pyth
CI_COMMIT=$(git rev-parse HEAD) scripts/cargo-install-all.sh ~/.local/share/solana/install/releases/"$TAG"

# run solana-test-validator with fresh ledger and custom slots-per-epoch and feature deactivated
~/.local/share/solana/install/releases/1.15.10-pyth/bin/solana-test-validator -r --slots-per-epoch 100 --deactivate-feature BawYFA2oeA4CacxgQgLn6ZwRWDq1ZPXruUuEbko8oPT5
```

### Activate Sysvar Feature(will go into effect at start of next epoch which is why we wanted a custom/lower `--slots-per-epoch` for the solana-test-validator)
```
~/.local/share/solana/install/releases/1.15.10-pyth/bin/solana feature activate <PATH_TO_ACCUMULATOR_FEATURE_KEYPAIR.json>
Activating enable accumulator sysvar (BawYFA2oeA4CacxgQgLn6ZwRWDq1ZPXruUuEbko8oPT5)

~/.local/share/solana/install/releases/1.15.10-pyth/bin/solana feature status -u http://localhost:8899                
Feature                                      | Status                  | Activation Slot | Description
// omitted for brevity
zk1snxsc6Fh3wsGNbbHAJNHiJoYgF29mMnTSusGx5EJ  | active since epoch 0    | 0               | enable Zk Token proof program and syscalls
BawYFA2oeA4CacxgQgLn6ZwRWDq1ZPXruUuEbko8oPT5 | pending until epoch 1   | NA              | enable accumulator sysvar #<GH_ISSUE_NUMBER>


Tool Software Version: 1.15.0
Software Version    Stake      RPC
1.15.0            100.00%  100.00%  <-- me



Tool Feature Set: 1754009961
Software Version  Feature Set    Stake      RPC
1.15.0             1754009961  100.00%  100.00%  <-- me


.local/share/solana/install/releases/1.15.10-pyth/bin/solana feature status -u http://localhost:8899                           
Feature                                      | Status                  | Activation Slot | Description
//... omitted for brevity
zk1snxsc6Fh3wsGNbbHAJNHiJoYgF29mMnTSusGx5EJ  | active since epoch 0    | 0               | enable Zk Token proof program and syscalls
BawYFA2oeA4CacxgQgLn6ZwRWDq1ZPXruUuEbko8oPT5 | active since epoch 1    | 100             | enable accumulator sysvar #<GH_ISSUE_NUMBER>


Tool Software Version: 1.15.0
Software Version    Stake      RPC
1.15.0            100.00%  100.00%  <-- me



Tool Feature Set: 1754009961
Software Version  Feature Set    Stake      RPC
1.15.0             1754009961  100.00%  100.00%  <-- me

```

Notes(still in rough draft form. will be cleaned up and moved to public teamspace once finalized):
1. https://www.notion.so/Solana-Feature-Flag-3db9e6f919ac4e52abef50b7db6c1a50
2. https://www.notion.so/Solana-Sysvar-f65fc12e568440b4b987d2a5aaa142b1
