### PR TITLE
[pythnet] Merkle Tree Updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64ct"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -5943,6 +5949,7 @@ dependencies = [
 name = "solana-pyth"
 version = "1.13.6"
 dependencies = [
+ "base64 0.21.0",
  "bincode",
  "borsh",
  "bytemuck",
@@ -5951,9 +5958,12 @@ dependencies = [
  "rand 0.7.3",
  "rustc_version 0.4.0",
  "serde",
+ "serde_json",
  "serde_wormhole",
  "sha3 0.10.7",
  "slow_primes",
+ "solana-client",
+ "solana-sdk 1.13.6",
  "wormhole-sdk",
 ]
 

--- a/pyth/Cargo.toml
+++ b/pyth/Cargo.toml
@@ -23,7 +23,11 @@ slow_primes = "0.1.14"
 wormhole-sdk = { git = "https://github.com/wormhole-foundation/wormhole" }
 
 [dev-dependencies]
+base64 = "0.21.0"
 rand = "0.7.0"
+serde_json = "1.0.96"
+solana-client = { path = "../client" }
+solana-sdk = { path = "../sdk" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pyth/src/hashers/keccak256.rs
+++ b/pyth/src/hashers/keccak256.rs
@@ -19,3 +19,22 @@ impl Hasher for Keccak256 {
         hasher.finalize().into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::hashers::Hasher,
+    };
+
+    #[test]
+    fn test_keccak256() {
+        let data = b"helloworld";
+        let hash_a = Keccak256::hashv(&[data]);
+
+        let data = [b"hello", b"world"];
+        let hash_b = Keccak256::hashv(&data);
+
+        assert_eq!(hash_a, hash_b);
+    }
+}

--- a/pyth/src/hashers/keccak256_160.rs
+++ b/pyth/src/hashers/keccak256_160.rs
@@ -1,0 +1,24 @@
+use {
+    crate::hashers::Hasher,
+    serde::Serialize,
+    sha3::{
+        Digest,
+        Keccak256,
+    },
+};
+
+#[derive(Clone, Default, Debug, Serialize)]
+pub struct Keccak160 {}
+
+impl Hasher for Keccak160 {
+    type Hash = [u8; 20];
+
+    fn hashv(data: &[impl AsRef<[u8]>]) -> [u8; 20] {
+        let mut hasher = Keccak256::new();
+        data.iter().for_each(|d| hasher.update(d));
+        let bytes: [u8; 32] = hasher.finalize().into();
+        let mut hash = [0u8; 20];
+        hash.copy_from_slice(&bytes[0..20]);
+        hash
+    }
+}


### PR DESCRIPTION
This PR updates the merkle tree implementation to match the Ethereum contract currently in progress. Along with this it implements the minor changes required to serialize this in a format that can be read by hermes. Currently this PR requires some refactoring to use the wire format types instead of `MerkleTree::serialize` but is opened here to allow others to progress based on the code. The PR will be updated soon with the serialize changes.