### PR TITLE
[pythnet] Helper scripts to synchronise with PythNet

### DIFF
--- a/pyth/Makefile
+++ b/pyth/Makefile
@@ -1,0 +1,70 @@
+# This Makefile contains helpers for testing PythNet modifications.
+
+VERSION = $(shell git describe --tags --dirty)
+
+
+.PHONY: help
+# Generate a help message for all targets in this Makefile.
+help:
+	@echo
+	@echo "Available Helpers for PythNet ($(VERSION)):"
+	@echo
+	@awk '/^[a-zA-Z\-_0-9%:\\]+/ { \
+		helpMessage = match(lastLine, /^# (.*)/); \
+		if (helpMessage) { \
+			helpCommand = substr($$1, 0, index($$1, ":")); \
+			helpMessage = substr(lastLine, RSTART + 2, RLENGTH); \
+			printf "  \033[36m%-30s\033[0m %s\n", helpCommand, helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+	@echo
+
+
+.PHONY: mirror
+# Download all known PythNet accounts to `accounts/`
+mirror:
+	@echo "Mirroring PythNet to Local"
+	@mkdir -p accounts/
+	@if [ -n "$(shell ls accounts/)" ]; then \
+		echo "Error: accounts/ is not empty. Are you sure you want to do this?"; \
+		exit 1; \
+	fi
+	@cargo run --example generate_pyth_data
+
+
+# We want to run ../target/debug/solana-test-validator with the accounts under
+# `accounts/` as arguments, the files are named after the addresses they should
+# belong in so we can do a transformation to the following:
+#
+# Given:
+#
+#     accounts/
+#     ├─ 6KUaSr9dsEkM9pTRQPWuWvVPvyWbcTPALHyetkV6r2R.json
+#     ├─ 8apEP8G5ZThPSXsff11nMoBmwo3nU176EEFZHM6jzLox.json
+#     └─ ...
+#
+# We want to run:
+#
+#     ../target/debug/solana-test-validator \
+#         --account 6KUaSr9dsEkM... accounts/6KUaSr9dsEkM...json \
+#         --account 8apEP8G5ZThP... accounts/8apEP8G5ZThP...json \
+#         ...
+#
+.PHONY: validator
+# Run a local PythNet validator loaded with all accounts under `accounts/`
+validator:
+	@echo "Running PythNet Validator"
+	@if [ ! -f ../target/debug/solana-test-validator ]; then \
+		echo "Error: ../target/debug/solana-test-validator does not exist. Maybe cargo build?"; \
+		exit 1; \
+	fi
+	../target/debug/solana-test-validator $(foreach addr,$(wildcard accounts/*.json),--account $(basename $(notdir $(addr))) $(addr)) \
+		--geyser-plugin-config pyth-geyser.json
+
+
+.PHONY: clean
+# Remove all accounts under `accounts/`
+clean:
+	@echo "Cleaning PythNet Accounts"
+	@rm -rf accounts/

--- a/pyth/README.md
+++ b/pyth/README.md
@@ -1,0 +1,33 @@
+# Pyth Extensions
+
+This module contains extensions to the Solana repository which contain
+definitions for cryptographic accumulators and helpers for implementing
+the bank changes required to emit them.
+
+## What are cryptographic accumulators?
+
+Cryptographic accumulators are data structures that allow users to compress
+multiple elements belonging to the same set into a succint representation that
+can still provide membership proofs. Merkle trees being an intuitive example of
+this abstraction. Through cryptographic accumulators, Pyth enables users to
+securely batch and send price information to other blockchains in a cheap and
+efficient manner.
+
+## Getting Started
+
+To get started testing these functionalities, you will need to build a PythNet
+validator. This can be done by running `cargo build` in the root of this
+repository. 
+
+You can run `make help` to find a set of useful commands you may find helpful
+for testing.
+
+### Quick Setup Instructions
+
+1. Clone the PythNet repository root, and `cd` the `pyth/` directory.
+2. Run `cargo build` to build the PythNet validator.
+3. Run `make clone` to clone PythNet accounts locally.
+4. Run `make validator` to run PythNet loaded with the accounts.
+
+You can use traditional Solana tooling (i.e `solana -ul account <address>`) to
+interact with the running test validator.

--- a/pyth/pyth-geyser.json
+++ b/pyth/pyth-geyser.json
@@ -1,0 +1,6 @@
+{
+    "libpath": "../geyser/target/release/libpyth_geyser.so",
+    "accounts_selector": {
+        "accounts" : ["*"]
+    }
+}


### PR DESCRIPTION
This PR adds a small `Makefile` that helps mirror all necessary PythNet accounts locally so the test validator can be used to test the accumulator (I.E the programs and price/product accounts). This Makefile makes assumptions about the layout of the solana repository and that you are inside the `pyth/` directory, but otherwise is also useful to serve just as documentation for how to work with PythNet in general.