### PR TITLE
[pythnet] Update MessageBuffer Parser

### DIFF
--- a/pyth/src/accumulators/merkle.rs
+++ b/pyth/src/accumulators/merkle.rs
@@ -118,7 +118,7 @@ impl<H: Hasher> MerkleAccumulator<H> {
         }
 
         let depth = (items.len() as f64).log2().ceil() as u32;
-        let mut tree: Vec<H::Hash> = Vec::with_capacity(1 << (depth + 1));
+        let mut tree: Vec<H::Hash> = vec![Default::default(); 1 << (depth + 1)];
 
         // Filling the leaf hashes
         for i in 0..(1 << depth) {


### PR DESCRIPTION
This updates the message buffer parsing which was previously not working correctly. This parser should be moved into the accumulator contract itself but for now this is a working implementation of the header parser.