### PR TITLE
[pythnet] Add Sorted Merkle Hashing

### DIFF
--- a/pyth/src/hashers.rs
+++ b/pyth/src/hashers.rs
@@ -28,6 +28,7 @@ where
         + Debug
         + Default
         + Eq
+        + PartialOrd
         + PartialEq
         + serde::Serialize
         + for<'a> Deserialize<'a>;


### PR DESCRIPTION
This fixes the node hashing to sort before hash, same as currently done in the Ethereum contract.