### PR TITLE
[pythnet] Merkle tree tests & fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,11 +2892,12 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3445,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -3461,6 +3462,7 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -5955,6 +5957,7 @@ dependencies = [
  "bytemuck",
  "fast-math",
  "hex",
+ "proptest",
  "rand 0.7.3",
  "rustc_version 0.4.0",
  "serde",
@@ -7733,6 +7736,12 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/pyth/Cargo.toml
+++ b/pyth/Cargo.toml
@@ -28,6 +28,7 @@ rand = "0.7.0"
 serde_json = "1.0.96"
 solana-client = { path = "../client" }
 solana-sdk = { path = "../sdk" }
+proptest = "1.1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION

#### Summary of Changes

- Don't hash during new
- Fix index lookup during check which is erroneously adding to the already correct position. (NODE/LEAF/NULL prefix prevents incorrect lookups here)
- Add arbitrary & prop test to exercise code.
- Changes depth calculation to a discrete one instead of float.