### PR TITLE
[pythnet] Improved negative MerkleAccumulator tests

### DIFF
--- a/pyth/examples/generate_pyth_data.rs
+++ b/pyth/examples/generate_pyth_data.rs
@@ -9,6 +9,7 @@ use {
     solana_pyth::PYTH_PID,
     solana_sdk::pubkey::Pubkey,
     std::str::FromStr,
+    std::io::Write,
 };
 
 fn main() {

--- a/pyth/src/hashers/keccak256.rs
+++ b/pyth/src/hashers/keccak256.rs
@@ -7,7 +7,7 @@ use {
     },
 };
 
-#[derive(Clone, Default, Debug, Serialize)]
+#[derive(Clone, Default, Debug, Eq, PartialEq, Serialize)]
 pub struct Keccak256 {}
 
 impl Hasher for Keccak256 {

--- a/pyth/src/hashers/keccak256_160.rs
+++ b/pyth/src/hashers/keccak256_160.rs
@@ -7,7 +7,7 @@ use {
     },
 };
 
-#[derive(Clone, Default, Debug, Serialize)]
+#[derive(Clone, Default, Debug, Eq, PartialEq, Serialize)]
 pub struct Keccak160 {}
 
 impl Hasher for Keccak160 {

--- a/pyth/src/hashers/prime.rs
+++ b/pyth/src/hashers/prime.rs
@@ -5,7 +5,7 @@ use {
     slow_primes::is_prime_miller_rabin,
 };
 
-#[derive(Clone, Default, Debug, Serialize)]
+#[derive(Clone, Default, Debug, Eq, PartialEq, Serialize)]
 pub struct PrimeHasher {}
 
 impl Hasher for PrimeHasher {


### PR DESCRIPTION
This adds another proptest which attempts to find passing proofs for a random tree. It also adds a test that specifically attempts a second preimage attack. Note that because `HashSet` ordering is non-deterministic it made testing a little tricky, so I opted to sort the data during MerkleTree construction to make the implementation easier to test. It has no impact on any other code but is worth noting.