### PR TITLE
Use keccak160

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2514,6 +2514,7 @@ impl Bank {
             byteorder::ReadBytesExt,
             pythnet_sdk::{
                 accumulators::{merkle::MerkleAccumulator, Accumulator},
+                hashers::keccak256_160::Keccak160,
                 pythnet::PYTH_PID,
                 MESSAGE_BUFFER_PID,
             },
@@ -2603,7 +2604,7 @@ impl Bank {
         // Generate a Message owned by Wormhole to be sent cross-chain. This short-circuits the
         // Wormhole message generation code that would normally be called, but the Guardian
         // set filters our messages so this does not pose a security risk.
-        if let Some(accumulator) = MerkleAccumulator::from_set(accounts) {
+        if let Some(accumulator) = MerkleAccumulator::<Keccak160>::from_set(accounts) {
             self.post_accumulator_attestation(accumulator, ring_index)?;
         }
 
@@ -2617,7 +2618,9 @@ impl Bank {
     /// TODO: Safe integer conversion checks if any are missed.
     fn post_accumulator_attestation(
         &self,
-        acc: pythnet_sdk::accumulators::merkle::MerkleAccumulator,
+        acc: pythnet_sdk::accumulators::merkle::MerkleAccumulator<
+            pythnet_sdk::hashers::keccak256_160::Keccak160,
+        >,
         ring_index: u32,
     ) -> std::result::Result<(), AccumulatorUpdateError> {
         use {


### PR DESCRIPTION
We are going to use the first 20bytes of Keccak256 to reduce the size of the proofs that result in less computation/gas cost on the environments that consume the proofs. Keccak256 is SHAKE128 and truncating it to 20 bytes is similar to SHAKE128 with the output size of 20 bytes and has 128bits of 2nd-preimage resistance. See [here](https://en.wikipedia.org/wiki/SHA-3#Security_against_quantum_attacks) for more information.