### PR TITLE
[pythnet] Set Rust version in CI to 1.60.0

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,7 +18,7 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.59.0
+  stable_version=1.60.0
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then


### PR DESCRIPTION
Pyth relies on `serde_wormhole` which depends on `wormhole/sdk/core`, this package uses the new `dep:` syntax for weak dependencies. This syntax cannot be parsed by Rust/Cargo < 1.60 which means the current release cannot be built with the shipped Rust version. Solana 1.14 onwards uses 1.60 anyway so this PR bumps us up for now.