### PR TITLE
[pythnet] add extra check to avoid panic

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2566,6 +2566,9 @@ impl Bank {
                     }
 
                     let end_offset = header_len + end;
+                    if end_offset as usize > data.len() {
+                        break;
+                    }
                     let accumulator_input_data = &data[header_begin as usize..end_offset as usize];
                     inputs.push(accumulator_input_data);
                     header_begin = end_offset;


### PR DESCRIPTION
### Sumamry
add additional check to ensure we won't panic when accessing the data. This situation should already be impossible but an additional check won't hurt and this whole loop will eventually be replaced by the ser/deserialization library in the pythnet_sdk
