### PR TITLE
Update pythnet sdk dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,7 +3570,7 @@ dependencies = [
 [[package]]
 name = "pythnet-sdk"
 version = "1.13.6"
-source = "git+https://github.com/pyth-network/pyth-crosschain?rev=407252000643f0c933ad23194ceabb6a6f0a4bf9#407252000643f0c933ad23194ceabb6a6f0a4bf9"
+source = "git+https://github.com/pyth-network/pyth-crosschain?rev=e670f57f89b05398ca352e4accb1e32724a8e1b4#e670f57f89b05398ca352e4accb1e32724a8e1b4"
 dependencies = [
  "bincode",
  "borsh",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -32,7 +32,7 @@ num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
 num_cpus = "1.13.1"
 ouroboros = "0.14.2"
-pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", version = "1.13.6", rev = "407252000643f0c933ad23194ceabb6a6f0a4bf9" }
+pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", version = "1.13.6", rev = "e670f57f89b05398ca352e4accb1e32724a8e1b4" }
 rand = "0.7.0"
 rayon = "1.5.1"
 regex = "1.5.4"

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
 log = "0.4.14"
 num-derive = "0.3"
 num-traits = "0.2"
-pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", version = "1.13.6", rev = "407252000643f0c933ad23194ceabb6a6f0a4bf9" }
+pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", version = "1.13.6", rev = "e670f57f89b05398ca352e4accb1e32724a8e1b4" }
 rustversion = "1.0.3"
 serde = "1.0.112"
 schemars = "0.8.8"


### PR DESCRIPTION
Previously the public key of the message buffer program was wrong. This PR updates pythnet sdk dependency to a newer version that has the correct public key.